### PR TITLE
Fix ESLint workflow

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -44,16 +44,19 @@ jobs:
           --output-file eslint-results.sarif
         continue-on-error: true
 
-      - name: Debug files
+      - name: Debug
         run: |
-          pwd
-          ls -R
+          echo "ref: ${{ github.ref }}"
+          echo "sha: ${{ github.sha }}"
+          echo "head sha: ${{ github.event.pull_request.head.sha }}"
+
 
       - name: Upload analysis results to GitHub
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
         uses: github/codeql-action/upload-sarif@v4
         with:
-          sarif_file: ./client/eslint-results.sarif
+          sarif_file: client/eslint-results.sarif
+          ref: ${{ github.ref }}
+          sha: ${{ github.sha }}
           wait-for-processing: true
-          category: eslint

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Debug
         run: |
-          echo: "event: ${{ github.event_name }}"
+          echo "event: ${{ github.event_name }}"
           echo "ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
           echo "sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -46,9 +46,9 @@ jobs:
 
       - name: Debug
         run: |
-          echo "ref: ${{ github.ref }}"
-          echo "sha: ${{ github.sha }}"
-          echo "head sha: ${{ github.event.pull_request.head.sha }}"
+          echo: "event: ${{ github.event_name }}"
+          echo "ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
+          echo "sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
 
       - name: Upload analysis results to GitHub
@@ -57,6 +57,6 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: client/eslint-results.sarif
-          ref: ${{ github.ref }}
-          sha: ${{ github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
+          sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           wait-for-processing: true

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -52,8 +52,8 @@ jobs:
 
       - name: "Debug: Inspect SARIF"
         run: |
-          cat client/eslint-results.sarif | jq '.runs[0].tool.driver.name'
-          cat client/eslint-results.sarif | jq '.runs | length'
+          cat eslint-results.sarif | jq '.runs[0].tool.driver.name'
+          cat eslint-results.sarif | jq '.runs | length'
 
       - name: Upload analysis results to GitHub
         env:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -44,12 +44,16 @@ jobs:
           --output-file eslint-results.sarif
         continue-on-error: true
 
-      - name: Debug
+      - name: "Debug: commit ref and sha"
         run: |
           echo "event: ${{ github.event_name }}"
-          echo "ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
-          echo "sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          echo "ref: ${{ github.ref }}
+          echo "sha: ${{ github.sha }}
 
+      - name: "Debug: Inspect SARIF"
+        run: |
+          cat client/eslint-results.sarif | jq '.runs[0].tool.driver.name'
+          cat client/eslint-results.sarif | jq '.runs | length'
 
       - name: Upload analysis results to GitHub
         env:
@@ -57,6 +61,6 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: client/eslint-results.sarif
-          ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
-          sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.ref }}
+          sha: ${{ github.sha }}
           wait-for-processing: true

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -41,8 +41,8 @@ jobs:
           SARIF_ESLINT_IGNORE_SUPPRESSED: "true"
         run: npx eslint .
           --format @microsoft/eslint-formatter-sarif
-          --output-file eslint-results.sarif
-        continue-on-error: true
+          --output-file eslint-results.sarif || true
+        continue-on-error: false
 
       - name: "Debug: commit ref and sha"
         run: |

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -44,10 +44,16 @@ jobs:
           --output-file eslint-results.sarif
         continue-on-error: true
 
+      - name: Debug files
+        run: |
+          pwd
+          ls -R
+
       - name: Upload analysis results to GitHub
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
         uses: github/codeql-action/upload-sarif@v4
         with:
-          sarif_file: client/eslint-results.sarif
+          sarif_file: ./client/eslint-results.sarif
           wait-for-processing: true
+          category: eslint


### PR DESCRIPTION
Currently, ESLint workflow triggers branch protection rules despite finishing successfully.

This PR fixes it.